### PR TITLE
Support for lilToon 1.2.0 to 1.2.9, performance improvements, QOL changes.

### DIFF
--- a/DPSShaderGenerator.cs.meta
+++ b/DPSShaderGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 363cd51323627a24b8f6d74129821de9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DPSShaderGeneratorCF.cs.meta
+++ b/DPSShaderGeneratorCF.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d0c82bb66e47864098e0ec71016ee3c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DPSShaderGeneratorLT.cs
+++ b/DPSShaderGeneratorLT.cs
@@ -45,12 +45,17 @@ namespace DPSGen
             EditorGUILayout.Space();
 
             EditorGUILayout.LabelField("Generate DPS lilToon");
-            EditorGUILayout.HelpBox("You need to import DPS and lilToon before running this script.", MessageType.Info);
+            EditorGUILayout.HelpBox("You need to import DPS and lilToon 1.2.8 before running this script.", MessageType.Info);
             EditorGUILayout.Space();
 
             if (GUILayout.Button("Generate"))
             {
                 RunLILGen();
+            }
+
+            if (GUILayout.Button("Remove lilToonDPS"))
+            {
+                RemovelilToonDPS();
             }
 
             EditorGUILayout.Space();
@@ -78,13 +83,6 @@ namespace DPSGen
                 EditorUtility.ClearProgressBar();
                 return;
             }
-            string selfpath = AssetDatabase.GUIDToAssetPath(selfguids[0]);
-            string outputPath = Directory.GetParent(Path.GetDirectoryName(selfpath)) + "/lilToonDPS";
-            log += "OutputPath: " + outputPath + "\n";
-            Directory.CreateDirectory(outputPath);
-            Directory.CreateDirectory(outputPath + "/Includes");
-
-            EditorUtility.DisplayProgressBar($"Creating Output Path: ", outputPath, (float) curstep++ / totalstep);
 
             string pathLil = null;
             string pathLilOpaque = null;
@@ -133,6 +131,14 @@ namespace DPSGen
                     EditorUtility.DisplayProgressBar($"Found Orifice Shader: ", sp, (float) curstep++ / totalstep);
                 }
             }
+
+            string selfpath = Directory.GetParent(Path.GetDirectoryName(pathLil)) + "";
+            string outputPath = Directory.GetParent(selfpath) + "/lilToonDPS";
+            log += "OutputPath: " + outputPath + "\n";
+            Directory.CreateDirectory(outputPath);
+            Directory.CreateDirectory(outputPath + "/Includes");
+
+            EditorUtility.DisplayProgressBar($"Creating Output Path: ", outputPath, (float) curstep++ / totalstep);
 
             if (pathLil == null || pathLilOutline == null || pathLilOpaque == null)
             {
@@ -926,6 +932,48 @@ namespace DPSGen
             AssetDatabase.Refresh();
 
             EditorUtility.ClearProgressBar();
+
+            log += "Done.\n";
+        }
+
+        private void RemovelilToonDPS()
+        {
+
+            log = "";
+
+            AssetDatabase.StartAssetEditing();
+
+            string[] guids1 = AssetDatabase.FindAssets("t:Shader");
+            foreach (string guid in guids1)
+            {
+                string sp = AssetDatabase.GUIDToAssetPath(guid);
+                if (sp.EndsWith("/lts_o_penetrator.shader"))
+                {
+                    AssetDatabase.DeleteAsset(Directory.GetParent(sp) + "");
+                    log += "Removed: " + Directory.GetParent(sp) + "\n";
+                }
+            }
+
+
+            string[] guids2 = AssetDatabase.FindAssets("t:Script");
+            foreach (string guid in guids2)
+            {
+                string sp = AssetDatabase.GUIDToAssetPath(guid);
+                if (sp.EndsWith("/lilInspectorDPS_Orifice.cs"))
+                {
+                    AssetDatabase.DeleteAsset(sp);
+                    log += "Removed: " + sp + "\n";
+                }  
+                if (sp.EndsWith("/lilInspectorDPS_Penetrator.cs"))
+                {
+                    AssetDatabase.DeleteAsset(sp);
+                    log += "Removed: " + sp + "\n";
+                }
+            }
+
+            AssetDatabase.StopAssetEditing();
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
 
             log += "Done.\n";
         }

--- a/DPSShaderGeneratorLT.cs
+++ b/DPSShaderGeneratorLT.cs
@@ -70,7 +70,7 @@ namespace DPSGen
                 return;
             }
             string selfpath = AssetDatabase.GUIDToAssetPath(selfguids[0]);
-            string outputPath = Directory.GetParent(Path.GetDirectoryName(selfpath)) + "/ShaderLIL";
+            string outputPath = Directory.GetParent(Path.GetDirectoryName(selfpath)) + "/lilToonDPS";
             log += "OutputPath: " + outputPath + "\n";
             Directory.CreateDirectory(outputPath);
             Directory.CreateDirectory(outputPath + "/Includes");
@@ -307,7 +307,7 @@ namespace DPSGen
                 AssetDatabase.DeleteAsset(opath);
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_common);
-                lines[4] = "#include \"Includes/lil_setting.hlsl\"";
+                lines[20] = "#include \"Includes/lil_setting.hlsl\"";
                 for (int i = 0; i < lines.Length; i++)
                     writer.WriteLine(lines[i]);
                 writer.Flush();
@@ -322,13 +322,13 @@ namespace DPSGen
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_struct);
                 string[] ovdlines = File.ReadAllLines(path_xs_OVD);
-                lines[46] = "";
                 lines[48] = "";
                 lines[50] = "";
                 lines[52] = "";
+                lines[54] = "";
                 for (int i = 0; i < lines.Length; i++)
                 {
-                    if (i == 106)
+                    if (i == 115)
                     {
                         //add vertexId
                         writer.WriteLine(ovdlines[13]);
@@ -370,7 +370,7 @@ namespace DPSGen
                         writer.WriteLine("#include \"OrificeDefines.cginc\"");
                         writer.WriteLine("#include \"OrificeFunctions.cginc\"");
                     }
-                    if (i == 52)
+                    if (i == 54)
                     {
                         // Orifice vert
                         writer.WriteLine(orifice_vert);
@@ -395,7 +395,7 @@ namespace DPSGen
                         writer.WriteLine("#include \"PenetratorDefines.cginc\"");
                         writer.WriteLine("#include \"PenetratorFunctions.cginc\"");
                     }
-                    if (i == 52)
+                    if (i == 54)
                     {
                         // Penetrator vert
                         writer.WriteLine(penetrator_vert);
@@ -413,7 +413,7 @@ namespace DPSGen
                 AssetDatabase.DeleteAsset(opath);
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_normal);
-                lines[176] = "#include \"Includes/lil_common_vert_orifice.hlsl\"";
+                lines[108] = "#include \"Includes/lil_common_vert_orifice.hlsl\"";
                 for (int i = 0; i < lines.Length; i++)
                     writer.WriteLine(lines[i]);
                 writer.Flush();
@@ -426,7 +426,7 @@ namespace DPSGen
                 AssetDatabase.DeleteAsset(opath);
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_normal);
-                lines[176] = "#include \"Includes/lil_common_vert_penetrator.hlsl\"";
+                lines[108] = "#include \"Includes/lil_common_vert_penetrator.hlsl\"";
                 for (int i = 0; i < lines.Length; i++)
                     writer.WriteLine(lines[i]);
                 writer.Flush();
@@ -498,7 +498,7 @@ namespace DPSGen
                 AssetDatabase.DeleteAsset(opath);
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_meta);
-                lines[45] = "#include \"Includes/lil_common_vert_orifice.hlsl\"";
+                lines[47] = "#include \"Includes/lil_common_vert_orifice.hlsl\"";
                 for (int i = 0; i < lines.Length; i++)
                 {
                     writer.WriteLine(lines[i]);
@@ -513,7 +513,7 @@ namespace DPSGen
                 AssetDatabase.DeleteAsset(opath);
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_meta);
-                lines[45] = "#include \"Includes/lil_common_vert_penetrator.hlsl\"";
+                lines[47] = "#include \"Includes/lil_common_vert_penetrator.hlsl\"";
                 for (int i = 0; i < lines.Length; i++)
                 {
                     writer.WriteLine(lines[i]);
@@ -705,10 +705,10 @@ namespace DPSGen
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_customEditor);
                 string[] xslines = File.ReadAllLines(pathXSOrifice);
-                lines[17] = "    public class lilToonInspectorDPS_Orifice : ShaderGUI";
+                lines[14] = "    public class lilToonInspectorDPS_Orifice : ShaderGUI";
                 for (int i = 0; i < lines.Length; i++)
                 {
-                    if (i == 387)
+                    if (i == 20)
                     {
                         for (int j = 12; j <= 22; j++)
                         {
@@ -720,7 +720,7 @@ namespace DPSGen
                         }
                     }
 
-                    if (i == 915)
+                    if (i == 36)
                     {
                         int stpos, edpos;
                         stpos = xslines[12].IndexOf('(') + 1;
@@ -728,7 +728,8 @@ namespace DPSGen
                         string label = xslines[12].Substring(stpos, edpos - stpos);
                         writer.WriteLine("GUIContent dpsod = new GUIContent(" + label + ");");
                     }
-                    if (i > 0 && lines[i - 1].IndexOf("materialEditor.ShaderProperty(invisible,") >= 0)
+
+                    if (i == 36)
                     {
                         for (int j = 12; j <= 22; j++)
                         {
@@ -747,7 +748,7 @@ namespace DPSGen
                         }
                     }
 
-                    if (i > 0 && lines[i - 1].IndexOf("invisible = FindProperty(") >= 0)
+                    if (i == 23)
                     {
                         for (int j = 12; j <= 22; j++)
                         {
@@ -758,6 +759,9 @@ namespace DPSGen
                             writer.WriteLine("dps" + prop_name + " = FindProperty(\"_" + prop_name + "\", props);");
                         }
                     }
+
+                    if (lines[i].IndexOf("isCustomShader  = material.shader.name.Contains") >= 0)
+                        lines[i] = lines[i].Replace("Optional", "Orifice");
 
                     if (lines[i].IndexOf("(lilPresetCategory)") >= 0)
                         lines[i] = lines[i].Replace("(lilPresetCategory)", "(lilToonInspector.lilPresetCategory)");
@@ -783,10 +787,10 @@ namespace DPSGen
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_customEditor);
                 string[] xslines = File.ReadAllLines(pathXSPenetrator);
-                lines[17] = "    public class lilToonInspectorDPS_Penetrator : ShaderGUI";
+                lines[14] = "    public class lilToonInspectorDPS_Penetrator : ShaderGUI";
                 for (int i = 0; i < lines.Length; i++)
                 {
-                    if (i == 387)
+                    if (i == 20)
                     {
                         for (int j = 12; j <= 22; j++)
                         {
@@ -798,7 +802,7 @@ namespace DPSGen
                         }
                     }
 
-                    if (i > 0 && lines[i - 1].IndexOf("materialEditor.ShaderProperty(invisible,") >= 0)
+                    if (i == 36)
                     {
                         for (int j = 12; j <= 22; j++)
                         {
@@ -814,7 +818,7 @@ namespace DPSGen
                         }
                     }
 
-                    if (i > 0 && lines[i - 1].IndexOf("invisible = FindProperty(") >= 0)
+                    if (i == 23)
                     {
                         for (int j = 12; j <= 22; j++)
                         {
@@ -825,6 +829,9 @@ namespace DPSGen
                             writer.WriteLine("dps" + prop_name + " = FindProperty(\"_" + prop_name + "\", props);");
                         }
                     }
+
+                    if (lines[i].IndexOf("isCustomShader  = material.shader.name.Contains") >= 0)
+                        lines[i] = lines[i].Replace("Optional", "Penetrator");
 
                     if (lines[i].IndexOf("(lilPresetCategory)") >= 0)
                         lines[i] = lines[i].Replace("(lilPresetCategory)", "(lilToonInspector.lilPresetCategory)");

--- a/DPSShaderGeneratorLT.cs
+++ b/DPSShaderGeneratorLT.cs
@@ -265,8 +265,10 @@ namespace DPSGen
                 }
             }
 
+            AssetDatabase.StopAssetEditing();
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
+            AssetDatabase.StartAssetEditing();
 
             List<string> newAssets = new List<string>();
 
@@ -691,8 +693,10 @@ namespace DPSGen
             AssetDatabase.DeleteAsset(outputPath + "/PenetratorDefines.cginc");
             AssetDatabase.CopyAsset(path_xs_PD, outputPath + "/PenetratorDefines.cginc");
 
+            AssetDatabase.StopAssetEditing();
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
+            AssetDatabase.StartAssetEditing();
 
             if (path_customEditor != null)
             {
@@ -840,6 +844,7 @@ namespace DPSGen
                 log += "Generated: " + opath + "\n";
             }
 
+            AssetDatabase.StopAssetEditing();
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
 

--- a/DPSShaderGeneratorLT.cs
+++ b/DPSShaderGeneratorLT.cs
@@ -45,12 +45,12 @@ namespace DPSGen
             EditorGUILayout.Space();
 
             EditorGUILayout.LabelField("Generate DPS lilToon");
-            EditorGUILayout.HelpBox("You need to import DPS and lilToon 1.2.8 before running this script.", MessageType.Info);
+            EditorGUILayout.HelpBox("You need to import DPS and lilToon before running this script.", MessageType.Info);
             EditorGUILayout.Space();
 
             if (GUILayout.Button("Generate"))
             {
-                RunLILGen();
+                GeneratelilToonDPS();
             }
 
             if (GUILayout.Button("Remove lilToonDPS"))
@@ -66,7 +66,7 @@ namespace DPSGen
             EditorGUILayout.EndScrollView();
         }
 
-        private void RunLILGen()
+        private void GeneratelilToonDPS()
         {
             log = "";
 
@@ -359,9 +359,15 @@ namespace DPSGen
                 AssetDatabase.DeleteAsset(opath);
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_common);
-                lines[20] = "#include \"Includes/lil_setting.hlsl\"";
+                // lines[20] = "#include \"Includes/lil_setting.hlsl\"";
                 for (int i = 0; i < lines.Length; i++)
+                {
+                    if (lines[i].IndexOf("lilToonSetting/lil_setting.hlsl") >= 0)
+                    {
+                        lines[i] = "#include \"Includes/lil_setting.hlsl\"";
+                    }
                     writer.WriteLine(lines[i]);
+                }
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
@@ -375,13 +381,25 @@ namespace DPSGen
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_struct);
                 string[] ovdlines = File.ReadAllLines(path_xs_OVD);
-                lines[48] = "";
-                lines[50] = "";
-                lines[52] = "";
-                lines[54] = "";
+                // lines[48] = "";
+                // lines[50] = "";
+                // lines[52] = "";
+                // lines[54] = "";
                 for (int i = 0; i < lines.Length; i++)
                 {
-                    if (i == 115)
+
+                    if (lines[i].IndexOf("#if defined(LIL_REQUIRE_APP_NORMAL)") >= 0)
+                    {
+                        lines[i] = "";
+                        lines[i+2] = "";
+                    }
+                    if (lines[i].IndexOf("#if defined(LIL_REQUIRE_APP_TANGENT)") >= 0)
+                    {
+                        lines[i] = "";
+                        lines[i+2] = "";
+                    }
+
+                    if (lines[i].IndexOf("LIL_VERTEX_INPUT_INSTANCE_ID") >= 0)
                     {
                         //add vertexId
                         writer.WriteLine(ovdlines[13]);
@@ -419,12 +437,13 @@ namespace DPSGen
                 string[] xslines = File.ReadAllLines(path_xs_VO);
                 for (int i = 0; i < lines.Length; i++)
                 {
-                    if (i == 3)
+                    if (lines[i].IndexOf("defined(LIL_V2F_OUT_BASE)") >= 0)
                     {
                         writer.WriteLine("#include \"OrificeDefines.cginc\"");
                         writer.WriteLine("#include \"OrificeFunctions.cginc\"");
                     }
-                    if (i == 54)
+                    
+                    if (lines[i].IndexOf("LIL_V2F_TYPE LIL_V2F_OUT") >= 0)
                     {
                         // Orifice vert
                         writer.WriteLine(orifice_vert);
@@ -445,12 +464,13 @@ namespace DPSGen
                 string[] xslines = File.ReadAllLines(path_xs_VP);
                 for (int i = 0; i < lines.Length; i++)
                 {
-                    if(i == 3)
+                    if (lines[i].IndexOf("defined(LIL_V2F_OUT_BASE)") >= 0)
                     {
                         writer.WriteLine("#include \"PenetratorDefines.cginc\"");
                         writer.WriteLine("#include \"PenetratorFunctions.cginc\"");
                     }
-                    if (i == 54)
+                    
+                    if (lines[i].IndexOf("LIL_V2F_TYPE LIL_V2F_OUT") >= 0)
                     {
                         // Penetrator vert
                         writer.WriteLine(penetrator_vert);
@@ -469,9 +489,13 @@ namespace DPSGen
                 AssetDatabase.DeleteAsset(opath);
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_normal);
-                lines[108] = "#include \"Includes/lil_common_vert_orifice.hlsl\"";
+                // lines[108] = "#include \"Includes/lil_common_vert_orifice.hlsl\"";
                 for (int i = 0; i < lines.Length; i++)
+                {
+                    if (lines[i].IndexOf("lil_common_vert") >= 0)
+                        lines[i] = lines[i].Replace("lil_common_vert", "lil_common_vert_orifice");
                     writer.WriteLine(lines[i]);
+                }
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
@@ -483,9 +507,13 @@ namespace DPSGen
                 AssetDatabase.DeleteAsset(opath);
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_normal);
-                lines[108] = "#include \"Includes/lil_common_vert_penetrator.hlsl\"";
+                // lines[108] = "#include \"Includes/lil_common_vert_penetrator.hlsl\"";
                 for (int i = 0; i < lines.Length; i++)
+                {
+                    if (lines[i].IndexOf("lil_common_vert") >= 0)
+                        lines[i] = lines[i].Replace("lil_common_vert", "lil_common_vert_penetrator");
                     writer.WriteLine(lines[i]);
+                }
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
@@ -498,9 +526,13 @@ namespace DPSGen
                 AssetDatabase.DeleteAsset(opath);
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_forward);
-                lines[6] = "#include \"Includes/lil_pass_forward_normal_orifice.hlsl\"";
+                // lines[6] = "#include \"Includes/lil_pass_forward_normal_orifice.hlsl\"";
                 for (int i = 0; i < lines.Length; i++)
+                {
+                    if (lines[i].IndexOf("lil_pass_forward_normal") >= 0)
+                        lines[i] = lines[i].Replace("lil_pass_forward_normal", "lil_pass_forward_normal_orifice");
                     writer.WriteLine(lines[i]);
+                }
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
@@ -512,9 +544,13 @@ namespace DPSGen
                 AssetDatabase.DeleteAsset(opath);
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_forward);
-                lines[6] = "#include \"Includes/lil_pass_forward_normal_penetrator.hlsl\"";
+                // lines[6] = "#include \"Includes/lil_pass_forward_normal_penetrator.hlsl\"";
                 for (int i = 0; i < lines.Length; i++)
+                {
+                    if (lines[i].IndexOf("lil_pass_forward_normal") >= 0)
+                        lines[i] = lines[i].Replace("lil_pass_forward_normal", "lil_pass_forward_normal_penetrator");
                     writer.WriteLine(lines[i]);
+                }
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
@@ -527,9 +563,11 @@ namespace DPSGen
                 AssetDatabase.DeleteAsset(opath);
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_shadow);
-                lines[36] = "#include \"Includes/lil_common_vert_orifice.hlsl\"";
+                // lines[36] = "#include \"Includes/lil_common_vert_orifice.hlsl\"";
                 for (int i = 0; i < lines.Length; i++)
                 {
+                    if (lines[i].IndexOf("lil_common_vert") >= 0)
+                        lines[i] = lines[i].Replace("lil_common_vert", "lil_common_vert_penetrator");
                     writer.WriteLine(lines[i]);
                 }
                 writer.Flush();
@@ -543,9 +581,11 @@ namespace DPSGen
                 AssetDatabase.DeleteAsset(opath);
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_shadow);
-                lines[36] = "#include \"Includes/lil_common_vert_penetrator.hlsl\"";
+                // lines[36] = "#include \"Includes/lil_common_vert_penetrator.hlsl\"";
                 for (int i = 0; i < lines.Length; i++)
                 {
+                    if (lines[i].IndexOf("lil_common_vert") >= 0)
+                        lines[i] = lines[i].Replace("lil_common_vert", "lil_common_vert_penetrator");
                     writer.WriteLine(lines[i]);
                 }
                 writer.Flush();
@@ -560,9 +600,11 @@ namespace DPSGen
                 AssetDatabase.DeleteAsset(opath);
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_meta);
-                lines[47] = "#include \"Includes/lil_common_vert_orifice.hlsl\"";
+                // lines[47] = "#include \"Includes/lil_common_vert_orifice.hlsl\"";
                 for (int i = 0; i < lines.Length; i++)
                 {
+                    if (lines[i].IndexOf("lil_common_vert") >= 0)
+                        lines[i] = lines[i].Replace("lil_common_vert", "lil_common_vert_orifice");
                     writer.WriteLine(lines[i]);
                 }
                 writer.Flush();
@@ -576,9 +618,11 @@ namespace DPSGen
                 AssetDatabase.DeleteAsset(opath);
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_meta);
-                lines[47] = "#include \"Includes/lil_common_vert_penetrator.hlsl\"";
+                // lines[47] = "#include \"Includes/lil_common_vert_penetrator.hlsl\"";
                 for (int i = 0; i < lines.Length; i++)
                 {
+                    if (lines[i].IndexOf("lil_common_vert") >= 0)
+                        lines[i] = lines[i].Replace("lil_common_vert", "lil_common_vert_penetrator");
                     writer.WriteLine(lines[i]);
                 }
                 writer.Flush();
@@ -646,7 +690,7 @@ namespace DPSGen
                 lines[0] = "Shader \"Hidden/lilToonOutline_Orifice\"";
                 for (int i = 0; i < lines.Length; i++)
                 {
-                    if (i == 13)
+                    if (lines[i].IndexOf("_VertexLightStrength") >= 0)
                     {
                         for (int j = 12; j <= 23; j++)
                             writer.WriteLine(xslines[j]);
@@ -675,7 +719,7 @@ namespace DPSGen
                 lines[0] = "Shader \"Hidden/lilToonOutline_Penetrator\"";
                 for (int i = 0; i < lines.Length; i++)
                 {
-                    if (i == 13)
+                    if (lines[i].IndexOf("_VertexLightStrength") >= 0)
                     {
                         // Penetrator Properties
                         for (int j = 12; j <= 23; j++)
@@ -706,7 +750,7 @@ namespace DPSGen
                 lines[0] = "Shader \"lilToon_Orifice\"";
                 for (int i = 0; i < lines.Length; i++)
                 {
-                    if (i == 13)
+                    if (lines[i].IndexOf("_VertexLightStrength") >= 0)
                     {
                         // Orifice Properties
                         for (int j = 12; j <= 23; j++)
@@ -736,7 +780,7 @@ namespace DPSGen
                 lines[0] = "Shader \"lilToon_Penetrator\"";
                 for (int i = 0; i < lines.Length; i++)
                 {
-                    if (i == 13)
+                    if (lines[i].IndexOf("_VertexLightStrength") >= 0)
                     {
                         // Penetrator Properties
                         for (int j = 12; j <= 23; j++)
@@ -777,63 +821,71 @@ namespace DPSGen
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_customEditor);
                 string[] xslines = File.ReadAllLines(pathXSOrifice);
-                lines[14] = "    public class lilToonInspectorDPS_Orifice : ShaderGUI";
+                // lines[14] = "    public class lilToonInspectorDPS_Orifice : ShaderGUI";
                 for (int i = 0; i < lines.Length; i++)
                 {
-                    if (i == 20)
+
+                    if (lines[i].IndexOf("class lilToonInspector") >= 0)
                     {
-                        for (int j = 12; j <= 22; j++)
+                        lines[i] = lines[i].Replace("lilToonInspector", "lilToonInspectorDPS_Orifice");
+                    }
+                    if (i > 2) 
+                    {
+                        if (lines[i-1].IndexOf("isCustomShader = false;") >= 0)
                         {
-                            int stpos, edpos;
-                            stpos = xslines[j].IndexOf('_') + 1;
-                            edpos = xslines[j].IndexOf('(');
-                            string prop_name = "dps" + xslines[j].Substring(stpos, edpos - stpos);
-                            writer.WriteLine("MaterialProperty " + prop_name + ";");
+                            for (int j = 12; j <= 22; j++)
+                            {
+                                int stpos, edpos;
+                                stpos = xslines[j].IndexOf('_') + 1;
+                                edpos = xslines[j].IndexOf('(');
+                                string prop_name = "dps" + xslines[j].Substring(stpos, edpos - stpos);
+                                writer.WriteLine("MaterialProperty " + prop_name + ";");
+                            }
                         }
-                    }
 
-                    if (i == 36)
-                    {
-                        int stpos, edpos;
-                        stpos = xslines[12].IndexOf('(') + 1;
-                        edpos = xslines[12].IndexOf(',');
-                        string label = xslines[12].Substring(stpos, edpos - stpos);
-                        writer.WriteLine("GUIContent dpsod = new GUIContent(" + label + ");");
-                    }
-
-                    if (i == 36)
-                    {
-                        for (int j = 12; j <= 22; j++)
+                        if (lines[i-2].IndexOf("GUIStyle offsetButton)") >= 0)
                         {
                             int stpos, edpos;
-                            stpos = xslines[j].IndexOf('_') + 1;
-                            edpos = xslines[j].IndexOf('(');
-                            string prop_name = "dps" + xslines[j].Substring(stpos, edpos - stpos);
-
-                            stpos = xslines[j].IndexOf('(') + 1;
-                            edpos = xslines[j].IndexOf(',');
-                            string label = xslines[j].Substring(stpos, edpos - stpos);
-                            if (j == 12)
-                                writer.WriteLine("materialEditor.TexturePropertySingleLine(dpsod, " + prop_name + ");");
-                            else
-                                writer.WriteLine("materialEditor.ShaderProperty(" + prop_name + ", " + label + ");");
+                            stpos = xslines[12].IndexOf('(') + 1;
+                            edpos = xslines[12].IndexOf(',');
+                            string label = xslines[12].Substring(stpos, edpos - stpos);
+                            writer.WriteLine("GUIContent dpsod = new GUIContent(" + label + ");");
                         }
-                    }
 
-                    if (i == 23)
-                    {
-                        for (int j = 12; j <= 22; j++)
+                        if (lines[i-2].IndexOf("GUIStyle offsetButton)") >= 0)
                         {
-                            int stpos, edpos;
-                            stpos = xslines[j].IndexOf('_') + 1;
-                            edpos = xslines[j].IndexOf('(');
-                            string prop_name = xslines[j].Substring(stpos, edpos - stpos);
-                            writer.WriteLine("dps" + prop_name + " = FindProperty(\"_" + prop_name + "\", props);");
+                            for (int j = 12; j <= 22; j++)
+                            {
+                                int stpos, edpos;
+                                stpos = xslines[j].IndexOf('_') + 1;
+                                edpos = xslines[j].IndexOf('(');
+                                string prop_name = "dps" + xslines[j].Substring(stpos, edpos - stpos);
+
+                                stpos = xslines[j].IndexOf('(') + 1;
+                                edpos = xslines[j].IndexOf(',');
+                                string label = xslines[j].Substring(stpos, edpos - stpos);
+                                if (j == 12)
+                                    writer.WriteLine("materialEditor.TexturePropertySingleLine(dpsod, " + prop_name + ");");
+                                else
+                                    writer.WriteLine("materialEditor.ShaderProperty(" + prop_name + ", " + label + ");");
+                            }
+                        }
+
+                        if (lines[i-2].IndexOf("void LoadCustomProperties") >= 0)
+                        {
+                            for (int j = 12; j <= 22; j++)
+                            {
+                                int stpos, edpos;
+                                stpos = xslines[j].IndexOf('_') + 1;
+                                edpos = xslines[j].IndexOf('(');
+                                string prop_name = xslines[j].Substring(stpos, edpos - stpos);
+                                writer.WriteLine("dps" + prop_name + " = FindProperty(\"_" + prop_name + "\", props);");
+                            }
                         }
                     }
 
                     if (lines[i].IndexOf("isCustomShader  = material.shader.name.Contains") >= 0)
-                        lines[i] = lines[i].Replace("Optional", "Orifice");
+                        lines[i] = "            isCustomShader  = true;";
 
                     if (lines[i].IndexOf("(lilPresetCategory)") >= 0)
                         lines[i] = lines[i].Replace("(lilPresetCategory)", "(lilToonInspector.lilPresetCategory)");
@@ -860,51 +912,60 @@ namespace DPSGen
                 StreamWriter writer = new StreamWriter(opath);
                 string[] lines = File.ReadAllLines(path_customEditor);
                 string[] xslines = File.ReadAllLines(pathXSPenetrator);
-                lines[14] = "    public class lilToonInspectorDPS_Penetrator : ShaderGUI";
+                // lines[14] = "    public class lilToonInspectorDPS_Penetrator : ShaderGUI";
                 for (int i = 0; i < lines.Length; i++)
                 {
-                    if (i == 20)
+
+                    if (lines[i].IndexOf("class lilToonInspector") >= 0)
                     {
-                        for (int j = 12; j <= 22; j++)
-                        {
-                            int stpos, edpos;
-                            stpos = xslines[j].IndexOf('_') + 1;
-                            edpos = xslines[j].IndexOf('(');
-                            string prop_name = "dps" + xslines[j].Substring(stpos, edpos - stpos);
-                            writer.WriteLine("MaterialProperty " + prop_name + ";");
-                        }
+                        lines[i] = lines[i].Replace("lilToonInspector", "lilToonInspectorDPS_Penetrator");
                     }
 
-                    if (i == 36)
+                    if (i > 2) 
                     {
-                        for (int j = 12; j <= 22; j++)
+                        if (lines[i-1].IndexOf("isCustomShader = false;") >= 0)
                         {
-                            int stpos, edpos;
-                            stpos = xslines[j].IndexOf('_') + 1;
-                            edpos = xslines[j].IndexOf('(');
-                            string prop_name = "dps" + xslines[j].Substring(stpos, edpos - stpos);
-
-                            stpos = xslines[j].IndexOf('(') + 1;
-                            edpos = xslines[j].IndexOf(',');
-                            string label = xslines[j].Substring(stpos, edpos - stpos);
-                            writer.WriteLine("materialEditor.ShaderProperty(" + prop_name + ", " + label + ");");
+                            for (int j = 12; j <= 22; j++)
+                            {
+                                int stpos, edpos;
+                                stpos = xslines[j].IndexOf('_') + 1;
+                                edpos = xslines[j].IndexOf('(');
+                                string prop_name = "dps" + xslines[j].Substring(stpos, edpos - stpos);
+                                writer.WriteLine("MaterialProperty " + prop_name + ";");
+                            }
                         }
-                    }
 
-                    if (i == 23)
-                    {
-                        for (int j = 12; j <= 22; j++)
+                        if (lines[i-2].IndexOf("GUIStyle offsetButton)") >= 0)
                         {
-                            int stpos, edpos;
-                            stpos = xslines[j].IndexOf('_') + 1;
-                            edpos = xslines[j].IndexOf('(');
-                            string prop_name = xslines[j].Substring(stpos, edpos - stpos);
-                            writer.WriteLine("dps" + prop_name + " = FindProperty(\"_" + prop_name + "\", props);");
+                            for (int j = 12; j <= 22; j++)
+                            {
+                                int stpos, edpos;
+                                stpos = xslines[j].IndexOf('_') + 1;
+                                edpos = xslines[j].IndexOf('(');
+                                string prop_name = "dps" + xslines[j].Substring(stpos, edpos - stpos);
+
+                                stpos = xslines[j].IndexOf('(') + 1;
+                                edpos = xslines[j].IndexOf(',');
+                                string label = xslines[j].Substring(stpos, edpos - stpos);
+                                writer.WriteLine("materialEditor.ShaderProperty(" + prop_name + ", " + label + ");");
+                            }
+                        }
+
+                        if (lines[i-2].IndexOf("void LoadCustomProperties") >= 0)
+                        {
+                            for (int j = 12; j <= 22; j++)
+                            {
+                                int stpos, edpos;
+                                stpos = xslines[j].IndexOf('_') + 1;
+                                edpos = xslines[j].IndexOf('(');
+                                string prop_name = xslines[j].Substring(stpos, edpos - stpos);
+                                writer.WriteLine("dps" + prop_name + " = FindProperty(\"_" + prop_name + "\", props);");
+                            }
                         }
                     }
 
                     if (lines[i].IndexOf("isCustomShader  = material.shader.name.Contains") >= 0)
-                        lines[i] = lines[i].Replace("Optional", "Penetrator");
+                        lines[i] = "            isCustomShader  = true;";
 
                     if (lines[i].IndexOf("(lilPresetCategory)") >= 0)
                         lines[i] = lines[i].Replace("(lilPresetCategory)", "(lilToonInspector.lilPresetCategory)");
@@ -974,6 +1035,8 @@ namespace DPSGen
             AssetDatabase.StopAssetEditing();
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
+
+            EditorUtility.ClearProgressBar();
 
             log += "Done.\n";
         }

--- a/DPSShaderGeneratorLT.cs
+++ b/DPSShaderGeneratorLT.cs
@@ -29,6 +29,8 @@ namespace DPSGen
 
         Vector2 scroll = Vector2.zero;
         string log = "";
+        int curstep = 0;
+        int totalstep = 46;
 
         private void OnEnable()
         {
@@ -63,10 +65,17 @@ namespace DPSGen
         {
             log = "";
 
+            AssetDatabase.StartAssetEditing();
+
             string[] selfguids = AssetDatabase.FindAssets("DPSShaderGenerator t:script");
             if (selfguids.Length == 0)
             {
                 log += "Error: Could not find this script from the asset database. Did you rename this script?";
+                EditorUtility.DisplayProgressBar($"Error: ", "Could not find this script from the asset database. Did you rename this script?", (float) curstep++ / totalstep);
+                AssetDatabase.StopAssetEditing();
+                AssetDatabase.SaveAssets();
+                AssetDatabase.Refresh();
+                EditorUtility.ClearProgressBar();
                 return;
             }
             string selfpath = AssetDatabase.GUIDToAssetPath(selfguids[0]);
@@ -74,6 +83,8 @@ namespace DPSGen
             log += "OutputPath: " + outputPath + "\n";
             Directory.CreateDirectory(outputPath);
             Directory.CreateDirectory(outputPath + "/Includes");
+
+            EditorUtility.DisplayProgressBar($"Creating Output Path: ", outputPath, (float) curstep++ / totalstep);
 
             string pathLil = null;
             string pathLilOpaque = null;
@@ -89,42 +100,58 @@ namespace DPSGen
                 {
                     pathLil = sp;
                     log += "lil: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found LilToon Shader: ", sp, (float) curstep++ / totalstep);
                 }
                 if (pathLilOutline == null && sp.EndsWith("/lts_o.shader"))
                 {
                     pathLilOutline = sp;
                     log += "lilOutline: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found LilToon Outline Shader: ", sp, (float) curstep++ / totalstep);
                 }
                 if (pathLilOpaque == null && sp.EndsWith("/ltspass_opaque.shader"))
                 {
                     pathLilOpaque = sp;
                     log += "lilOpaque: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found LilToon Opaque Shader: ", sp, (float) curstep++ / totalstep);
                 }
                 if (pathXSOrifice == null && sp.EndsWith("/XSToon2.0 Orifice.shader"))
                 {
                     pathXSOrifice = sp;
                     log += "XSOrifice: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found XSOrifice Shader: ", sp, (float) curstep++ / totalstep);
                 }
                 if (pathXSPenetrator == null && sp.EndsWith("/XSToon2.0 Penetrator.shader"))
                 {
                     pathXSPenetrator = sp;
                     log += "XSPenetrator: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found XSPenetrator Shader: ", sp, (float) curstep++ / totalstep);
                 }
                 if (pathOrifice == null && sp.EndsWith("/Orifice.shader"))
                 {
                     pathOrifice = sp;
                     log += "Orifice: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found Orifice Shader: ", sp, (float) curstep++ / totalstep);
                 }
             }
 
             if (pathLil == null || pathLilOutline == null || pathLilOpaque == null)
             {
                 log += "Error: lilToon not found. Please import lilToon.";
+                EditorUtility.DisplayProgressBar($"Error: ", "lilToon not found. Please import lilToon.", (float) curstep++ / totalstep);
+                AssetDatabase.StopAssetEditing();
+                AssetDatabase.SaveAssets();
+                AssetDatabase.Refresh();
+                EditorUtility.ClearProgressBar();
                 return;
             }
             if (pathXSOrifice == null || pathXSPenetrator == null || pathOrifice == null)
             {
                 log += "Error: DPS not found. Please import DPS.";
+                EditorUtility.DisplayProgressBar($"Error: ", "DPS not found. Please import DPS.", (float) curstep++ / totalstep);
+                AssetDatabase.StopAssetEditing();
+                AssetDatabase.SaveAssets();
+                AssetDatabase.Refresh();
+                EditorUtility.ClearProgressBar();
                 return;
             }
             
@@ -145,36 +172,43 @@ namespace DPSGen
                 {
                     path_forward = sp;
                     log += "path_forward: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found Liltoon Forward Pass: ", sp, (float) curstep++ / totalstep);
                 }
                 if (path_normal == null && sp.EndsWith("/lil_pass_forward_normal.hlsl"))
                 {
                     path_normal = sp;
                     log += "pass_forward_normal: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found Liltoon Forward Normal Pass: ", sp, (float) curstep++ / totalstep);
                 }
                 else if (path_shadow == null && sp.EndsWith("/lil_pass_shadowcaster.hlsl"))
                 {
                     path_shadow = sp;
                     log += "pass_shadowcaster: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found Liltoon Shadowcaster Pass: ", sp, (float) curstep++ / totalstep);
                 }
                 else if (path_meta == null && sp.EndsWith("/lil_pass_meta.hlsl"))
                 {
                     path_meta = sp;
                     log += "pass_meta: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found Liltoon Meta Pass: ", sp, (float) curstep++ / totalstep);
                 }
                 else if (path_common == null && sp.EndsWith("/lil_common.hlsl"))
                 {
                     path_common = sp;
                     log += "lil_common: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found Liltoon Common: ", sp, (float) curstep++ / totalstep);
                 }
                 else if (path_struct == null && sp.EndsWith("/lil_common_appdata.hlsl"))
                 {
                     path_struct = sp;
                     log += "lil_common_appdata: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found Liltoon Common Appdata Pass: ", sp, (float) curstep++ / totalstep);
                 }
                 else if (path_vert == null && sp.EndsWith("/lil_common_vert.hlsl"))
                 {
                     path_vert = sp;
                     log += "lil_common_vert: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found Liltoon Common Vert: ", sp, (float) curstep++ / totalstep);
                 }
                 else
                 {
@@ -194,6 +228,7 @@ namespace DPSGen
                 if (path_setting == null && sp.EndsWith("/lil_setting.hlsl"))
                 {
                     log += "lilSetting: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found Liltoon Settings: ", sp, (float) curstep++ / totalstep);
                     string filename = Path.GetFileName(sp);
                     AssetDatabase.DeleteAsset(outputPath + "/Includes/" + filename);
                     AssetDatabase.CopyAsset(sp, outputPath + "/Includes/" + filename);
@@ -209,6 +244,7 @@ namespace DPSGen
                 {
                     path_customEditor = sp;
                     log += "CustomEditor: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found Liltoon Inspector: ", sp, (float) curstep++ / totalstep);
                     break;
                 }
             }
@@ -228,26 +264,31 @@ namespace DPSGen
                 {
                     path_xs_OD = sp;
                     log += "OrificeDefines: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found OrificeDefines: ", sp, (float) curstep++ / totalstep);
                 }
                 if (path_xs_PD == null && sp.EndsWith("/PenetratorDefines.cginc"))
                 {
                     path_xs_PD = sp;
                     log += "PenetratorDefines: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found PenetratorDefines: ", sp, (float) curstep++ / totalstep);
                 }
                 if (path_xs_OVD == null && sp.EndsWith("/XSDefinesOrifice.cginc"))
                 {
                     path_xs_OVD = sp;
                     log += "DefinesOrificeVertexData: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found DefinesOrificeVertexData: ", sp, (float) curstep++ / totalstep);
                 }
                 if (path_xs_VO == null && sp.EndsWith("/XSVertOrifice.cginc"))
                 {
                     path_xs_VO = sp;
                     log += "XSVertOrifice: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found XSVertOrifice: ", sp, (float) curstep++ / totalstep);
                 }
                 if (path_xs_VP == null && sp.EndsWith("/XSVert.cginc"))
                 {
                     path_xs_VP = sp;
                     log += "XSPenetratorVert: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found XSPenetratorVert: ", sp, (float) curstep++ / totalstep);
                 }
             }
 
@@ -262,8 +303,11 @@ namespace DPSGen
                 {
                     path_DPS_func = sp;
                     log += "DPSFunctions: " + sp + "\n";
+                    EditorUtility.DisplayProgressBar($"Found DPSFunctions: ", sp, (float) curstep++ / totalstep);
                 }
             }
+
+            EditorUtility.DisplayProgressBar($"Refreshing AssetDatabase", "1/3", (float) curstep++ / totalstep);
 
             AssetDatabase.StopAssetEditing();
             AssetDatabase.SaveAssets();
@@ -285,6 +329,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated OrificeFunctions: ", opath, (float) curstep++ / totalstep);
             }
             if (path_DPS_func != null)
             {
@@ -299,6 +344,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated PenetratorFunctions: ", opath, (float) curstep++ / totalstep);
             }
 
             if (path_common != null)
@@ -313,6 +359,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Common: ", opath, (float) curstep++ / totalstep);
             }
 
             if (path_struct != null)
@@ -338,6 +385,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Common Appdata: ", opath, (float) curstep++ / totalstep);
             }
 
             string orifice_vert = "";
@@ -380,6 +428,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Common Vert Orifice: ", opath, (float) curstep++ / totalstep);
             }
             if (path_vert != null)
             {
@@ -405,6 +454,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Common Vert Penetrator: ", opath, (float) curstep++ / totalstep);
             }
 
             if (path_normal != null)
@@ -419,6 +469,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Forward Normal Orifice Pass: ", opath, (float) curstep++ / totalstep);
             }
             if (path_normal != null)
             {
@@ -432,6 +483,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Forward Normal Penetrator Pass: ", opath, (float) curstep++ / totalstep);
             }
 
             if (path_forward != null)
@@ -446,6 +498,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Forward Orifice Pass: ", opath, (float) curstep++ / totalstep);
             }
             if (path_forward != null)
             {
@@ -459,6 +512,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Forward Penetrator Pass: ", opath, (float) curstep++ / totalstep);
             }
 
             if (path_shadow != null)
@@ -475,6 +529,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Shadowcaster Orifice Pass: ", opath, (float) curstep++ / totalstep);
             }
             if (path_shadow != null)
             {
@@ -490,6 +545,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Shadowcaster Penetrator Pass: ", opath, (float) curstep++ / totalstep);
             }
 
             if (path_meta != null)
@@ -506,6 +562,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Meta Orifice Pass: ", opath, (float) curstep++ / totalstep);
             }
             if (path_meta != null)
             {
@@ -521,6 +578,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Meta Penetrator Pass: ", opath, (float) curstep++ / totalstep);
             }
 
             if (pathLilOpaque != null)
@@ -545,6 +603,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Opaque Orifice Shader: ", opath, (float) curstep++ / totalstep);
             }
             if (pathLilOpaque != null)
             {
@@ -568,6 +627,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Opaque Penetrator Shader: ", opath, (float) curstep++ / totalstep);
             }
 
             if (pathLilOutline != null)
@@ -597,6 +657,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Orifice Outline Shader: ", opath, (float) curstep++ / totalstep);
             }
             if (pathLilOutline != null)
             {
@@ -626,6 +687,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Penetrator Outline Shader: ", opath, (float) curstep++ / totalstep);
             }
 
             if (pathLil != null)
@@ -656,6 +718,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Orifice Shader: ", opath, (float) curstep++ / totalstep);
             }
             if (pathLil != null)
             {
@@ -685,6 +748,7 @@ namespace DPSGen
                 writer.Flush();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Penetrator Shader: ", opath, (float) curstep++ / totalstep);
             }
 
             AssetDatabase.DeleteAsset(outputPath + "/OrificeDefines.cginc");
@@ -692,6 +756,8 @@ namespace DPSGen
 
             AssetDatabase.DeleteAsset(outputPath + "/PenetratorDefines.cginc");
             AssetDatabase.CopyAsset(path_xs_PD, outputPath + "/PenetratorDefines.cginc");
+
+            EditorUtility.DisplayProgressBar($"Refreshing AssetDatabase", "2/3", (float) curstep++ / totalstep);
 
             AssetDatabase.StopAssetEditing();
             AssetDatabase.SaveAssets();
@@ -779,6 +845,7 @@ namespace DPSGen
                 writer.Close();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Orifice Inspector: ", opath, (float) curstep++ / totalstep);
             }
             if (path_customEditor != null)
             {
@@ -849,11 +916,16 @@ namespace DPSGen
                 writer.Close();
                 newAssets.Add(opath);
                 log += "Generated: " + opath + "\n";
+                EditorUtility.DisplayProgressBar($"Generated Penetrator Inspector: ", opath, (float) curstep++ / totalstep);
             }
+
+            EditorUtility.DisplayProgressBar($"Done!", "3/3", (float) curstep++ / totalstep);
 
             AssetDatabase.StopAssetEditing();
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
+
+            EditorUtility.ClearProgressBar();
 
             log += "Done.\n";
         }

--- a/DPSShaderGeneratorLT.cs.meta
+++ b/DPSShaderGeneratorLT.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2fe2d22a567e984793de640117acb4c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DPSShaderGeneratorWF.cs.meta
+++ b/DPSShaderGeneratorWF.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4387f9ba73680464ba2b2b4024d11a8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LICENSE.meta
+++ b/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a47a1cd396893674ca9ca6f279ecdcf1
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 54f23376159b69449b2d45002078a46f
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Now supports lilToon 1.2.0 to 1.2.9 and *hopefully* future releases.

Added StartAssetEditing() and StopAssetEditing() to make Unity only import assets once they have been fully generated.

https://docs.unity3d.com/ScriptReference/AssetDatabase.StartAssetEditing.html 
> Starts importing Assets into the Asset Database. This lets you group several Asset imports together into one larger import.

These small changes dropped the lengthy generation time to **30 seconds**.

Also added QOL progress bar and changed output folder to lilToonDPS for organization.